### PR TITLE
Speed up build time with ensure "WinVerifyTrust" isn't triggered for each project and file while building projects

### DIFF
--- a/src/tools/Wendy/Wendy.psm1
+++ b/src/tools/Wendy/Wendy.psm1
@@ -1,5 +1,5 @@
 $PSScriptRoot = Split-Path  $script:MyInvocation.MyCommand.Path
 $ErrorActionPreference = "Stop"
 
-Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.tests.ps1 | Foreach-Object{ . $_.FullName }
+Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.tests.ps1 | Foreach-Object{ . ([scriptblock]::Create([io.file]::ReadAllText($_.FullName))) }
 Export-ModuleMember -Function * -Alias *


### PR DESCRIPTION
Since few weeks we faced the issue that projects are built much slower then usually. This is a fix for that. 